### PR TITLE
Fix hero spacing under sticky bar

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -11,7 +11,7 @@ const Hero = () => {
   };
 
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden lg:mt-12">
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden lg:pt-12">
       {/* Background Image with Overlay */}
       <div 
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"


### PR DESCRIPTION
## Summary
- adjust hero section spacing by using padding instead of margin

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852cce60dec8332a25e8f5327157ce8