### PR TITLE
Enable compression and optimize bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,8 @@
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
-        "vite": "^5.4.1"
+        "vite": "^5.4.1",
+        "vite-plugin-compression": "^0.5.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7094,6 +7095,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/vite-plugin-compression": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+      "integrity": "sha512-",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.23.8",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vite-plugin-compression": "^0.5.1"
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,13 +1,14 @@
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, lazy, Suspense } from "react";
 import StickyBar from "@/components/StickyBar";
 import Hero from "@/components/Hero";
-import Benefits from "@/components/Benefits";
-import MetabolicSyndrome from "@/components/MetabolicSyndrome";
-import TechnicalLibrary from "@/components/TechnicalLibrary";
-import LeadForm from "@/components/LeadForm";
-import FAQ from "@/components/FAQ";
-import Footer from "@/components/Footer";
+
+const Benefits = lazy(() => import("@/components/Benefits"));
+const MetabolicSyndrome = lazy(() => import("@/components/MetabolicSyndrome"));
+const TechnicalLibrary = lazy(() => import("@/components/TechnicalLibrary"));
+const LeadForm = lazy(() => import("@/components/LeadForm"));
+const FAQ = lazy(() => import("@/components/FAQ"));
+const Footer = lazy(() => import("@/components/Footer"));
 
 const Index = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -21,13 +22,15 @@ const Index = () => {
       <StickyBar />
       <main className={`transition-opacity duration-1000 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
         <Hero />
-        <Benefits />
-        <MetabolicSyndrome />
-        <TechnicalLibrary />
-        <LeadForm />
-        <FAQ />
+        <Suspense fallback={null}>
+          <Benefits />
+          <MetabolicSyndrome />
+          <TechnicalLibrary />
+          <LeadForm />
+          <FAQ />
+          <Footer />
+        </Suspense>
       </main>
-      <Footer />
     </div>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import viteCompression from "vite-plugin-compression";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
@@ -11,12 +12,30 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
+    viteCompression(),
+    viteCompression({ algorithm: 'brotliCompress', ext: '.br' }),
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('react')) {
+              return 'react';
+            }
+            if (id.includes('@mui')) {
+              return 'mui';
+            }
+          }
+        },
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary
- add `vite-plugin-compression` dev dependency
- configure Vite to create manual chunks for React and MUI
- enable Brotli/gzip asset generation
- lazy load heavy page components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534161ae8c8332a4ea836a19866ae6